### PR TITLE
データベースのテーブル設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,27 @@
 
 ## items テーブル
 
-| Column           | Type      | Options                                     |
-| ---------------- | --------- | ------------------------------------------- |
-| name             | string    | null: false                                 |
-| introduction     | text      | null: false                                 |
-| category_id      | integer   | null: false                                 |
-| status_id        | integer   | null: false                                 |
-| shipping_fee_id  | integer   | null: false                                 |
-| send_from_id     | integer   | null: false                                 |
-| shipping_days_id | integer   | null: false                                 |
-| price            | integer   | null: false                                 |
-| user             | reference | reference | null: false, foreign_key: true  |
+| Column           | Type       | Options                        |
+| ---------------- | ---------- | ------------------------------ |
+| name             | string     | null: false                    |
+| introduction     | text       | null: false                    |
+| category_id      | integer    | null: false                    |
+| status_id        | integer    | null: false                    |
+| shipping_fee_id  | integer    | null: false                    |
+| send_from_id     | integer    | null: false                    |
+| shipping_days_id | integer    | null: false                    |
+| price            | integer    | null: false                    |
+| user             | references | null: false, foreign_key: true |
 
 - has_one :purchase
 - belongs_to :user
 
 
 ## purchases テーブル
-| Column | Type      | Options                         |
-| ---------- | --------- | ------------------------------- |
-| user   | reference | null: false, foreign_key: true  |
-| item   | reference | null: false, foreign_key: true  |
+| Column | Type       | Options                         |
+| ------ | ---------- | ------------------------------- |
+| user   | references | null: false, foreign_key: true  |
+| item   | references | null: false, foreign_key: true  |
 
 - belongs_to :user
 - belongs_to :item
@@ -49,14 +49,14 @@
 
 
 ## addresses テーブル
-| Column          | Type      | Options                         |
-| --------------- | --------- | ------------------------------- |
-| post_number     | string    | null:false                      |
-| prefecture _id  | integer   | null:false                      |
-| village_name    | string    | null:false                      |
-| village_number  | string    | null:false                      |
-| building_detail | string    |                                 |
-| tele_number     | string    | null:false                      |
-| purchase        | reference | null: false, foreign_key: true  |
+| Column          | Type       | Options                         |
+| --------------- | ---------- | ------------------------------- |
+| post_number     | string     | null:false                      |
+| prefecture _id  | integer    | null:false                      |
+| village_name    | string     | null:false                      |
+| village_number  | string     | null:false                      |
+| building_detail | string     |                                 |
+| tele_number     | string     | null:false                      |
+| purchase        | references | null: false, foreign_key: true  |
 
 - belongs_to :purchase

--- a/README.md
+++ b/README.md
@@ -21,27 +21,27 @@
 
 ## items テーブル
 
-| Column        | Type      | Options                                     |
-| ------------- | --------- | ------------------------------------------- |
-| name          | string    | null: false                                 |
-| introduction  | text      | null: false                                 |
-| category      | integer   | null: false                                 |
-| status        | integer   | null: false                                 |
-| shipping_fee  | integer   | null: false                                 |
-| send_from     | integer   | null: false                                 |
-| shipping_days | integer   | null: false                                 |
-| price         | integer   | null: false                                 |
-| user_id       | reference | reference | null: false, foreign_key: true  |
+| Column           | Type      | Options                                     |
+| ---------------- | --------- | ------------------------------------------- |
+| name             | string    | null: false                                 |
+| introduction     | text      | null: false                                 |
+| category_id      | integer   | null: false                                 |
+| status_id        | integer   | null: false                                 |
+| shipping_fee_id  | integer   | null: false                                 |
+| send_from_id     | integer   | null: false                                 |
+| shipping_days_id | integer   | null: false                                 |
+| price            | integer   | null: false                                 |
+| user             | reference | reference | null: false, foreign_key: true  |
 
 - has_one :purchase
 - belongs_to :user
 
 
 ## purchases テーブル
-| Column     | Type      | Options                         |
+| Column | Type      | Options                         |
 | ---------- | --------- | ------------------------------- |
-| user_id    | reference | null: false, foreign_key: true  |
-| item_id    | reference | null: false, foreign_key: true  |
+| user   | reference | null: false, foreign_key: true  |
+| item   | reference | null: false, foreign_key: true  |
 
 - belongs_to :user
 - belongs_to :item
@@ -51,14 +51,12 @@
 ## addresses テーブル
 | Column          | Type      | Options                         |
 | --------------- | --------- | ------------------------------- |
-| post_number     | integer   | null:false                      |
-| prefecture      | integer   | null:false                      |
+| post_number     | string    | null:false                      |
+| prefecture _id  | integer   | null:false                      |
 | village_name    | string    | null:false                      |
 | village_number  | string    | null:false                      |
-| building_detail | string    | null:false                      |
-| tele_number     | integer   | null:false                      |
-| user_id         | reference | null: false, foreign_key: true  |
-| item_id         | reference | null: false, foreign_key: true  |
-| purchase_id     | reference | null: false, foreign_key: true  |
+| building_detail | string    |                                 |
+| tele_number     | string    | null:false                      |
+| purchase        | reference | null: false, foreign_key: true  |
 
 - belongs_to :purchase

--- a/README.md
+++ b/README.md
@@ -1,24 +1,58 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# テーブル設計
 
-Things you may want to cover:
+## users テーブル
 
-* Ruby version
+| Column    | Type    | Options                   |
+| --------- | ------- | ------------------------- |
+| nickname  | string  | null: false, unique: true |
+| email     | string  | null: false               |
+| password  | string  | null: false               |
+| birthday  | integer | null: false               |
+| real_name | string  | null: false               |
 
-* System dependencies
+- has_many :items
+- has_many :purchases
+- has_one :address
 
-* Configuration
 
-* Database creation
+## items テーブル
 
-* Database initialization
+| Column       | Type      | Options                                     |
+| ------------ | --------- | ------------------------------------------- |
+| name         | string    | null: false                                 |
+| introduction | text      | null: false                                 |
+| item_profile | text      | null: false                                 |
+| category     | string    | null: false                                 |
+| status       | string    | null: false                                 |
+| price        | integer   | null: false                                 |
+| user_id      | reference | reference | null: false, foreign_key: true  |
 
-* How to run the test suite
+- has_one :purchase
+- belongs_to :user
+- has_one :address
 
-* Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
+## purchases テーブル
+| Column     | Type      | Options                         |
+| ---------- | --------- | ------------------------------- |
+| address_id | reference | null: false, foreign_key: true  |
+| user_id    | reference | null: false, foreign_key: true  |
+| item_id    | reference | null: false, foreign_key: true  |
 
-* ...
+- belongs_to :user
+- belongs_to :item
+- belongs_to :address
+
+
+## addresses テーブル
+| Column  | Type      | Options                         |
+| ------- | --------- | ------------------------------- |
+| address | text      | null:false                      |
+| user_id | reference | null: false, foreign_key: true  |
+| item_id | reference | null: false, foreign_key: true  |
+
+- belongs_to :user
+- belongs_to :item
+- has_one :purchase

--- a/README.md
+++ b/README.md
@@ -4,55 +4,61 @@
 
 ## users テーブル
 
-| Column    | Type    | Options                   |
-| --------- | ------- | ------------------------- |
-| nickname  | string  | null: false, unique: true |
-| email     | string  | null: false               |
-| password  | string  | null: false               |
-| birthday  | integer | null: false               |
-| real_name | string  | null: false               |
+| Column             | Type    | Options                   |
+| ------------------ | ------- | ------------------------- |
+| nickname           | string  | null: false, unique: true |
+| email              | string  | null: false, unique: true |
+| encrypted_password | string  | null: false               |
+| birthday           | date    | null: false               |
+| real_first_name    | string  | null: false               |
+| real_family_name   | string  | null: false               |
+| first_furigana     | string  | null: false               |
+| family_furigana    | string  | null: false               |
 
 - has_many :items
 - has_many :purchases
-- has_one :address
 
 
 ## items テーブル
 
-| Column       | Type      | Options                                     |
-| ------------ | --------- | ------------------------------------------- |
-| name         | string    | null: false                                 |
-| introduction | text      | null: false                                 |
-| item_profile | text      | null: false                                 |
-| category     | string    | null: false                                 |
-| status       | string    | null: false                                 |
-| price        | integer   | null: false                                 |
-| user_id      | reference | reference | null: false, foreign_key: true  |
+| Column        | Type      | Options                                     |
+| ------------- | --------- | ------------------------------------------- |
+| name          | string    | null: false                                 |
+| introduction  | text      | null: false                                 |
+| category      | integer   | null: false                                 |
+| status        | integer   | null: false                                 |
+| shipping_fee  | integer   | null: false                                 |
+| send_from     | integer   | null: false                                 |
+| shipping_days | integer   | null: false                                 |
+| price         | integer   | null: false                                 |
+| user_id       | reference | reference | null: false, foreign_key: true  |
 
 - has_one :purchase
 - belongs_to :user
-- has_one :address
 
 
 ## purchases テーブル
 | Column     | Type      | Options                         |
 | ---------- | --------- | ------------------------------- |
-| address_id | reference | null: false, foreign_key: true  |
 | user_id    | reference | null: false, foreign_key: true  |
 | item_id    | reference | null: false, foreign_key: true  |
 
 - belongs_to :user
 - belongs_to :item
-- belongs_to :address
+- has_one    :address
 
 
 ## addresses テーブル
-| Column  | Type      | Options                         |
-| ------- | --------- | ------------------------------- |
-| address | text      | null:false                      |
-| user_id | reference | null: false, foreign_key: true  |
-| item_id | reference | null: false, foreign_key: true  |
+| Column          | Type      | Options                         |
+| --------------- | --------- | ------------------------------- |
+| post_number     | integer   | null:false                      |
+| prefecture      | integer   | null:false                      |
+| village_name    | string    | null:false                      |
+| village_number  | string    | null:false                      |
+| building_detail | string    | null:false                      |
+| tele_number     | integer   | null:false                      |
+| user_id         | reference | null: false, foreign_key: true  |
+| item_id         | reference | null: false, foreign_key: true  |
+| purchase_id     | reference | null: false, foreign_key: true  |
 
-- belongs_to :user
-- belongs_to :item
-- has_one :purchase
+- belongs_to :purchase


### PR DESCRIPTION
# what
テーブルの設計
# why
ユーザー、アイテム、purchase(購入)、アドレス(発送先)の４つのテーブル

### 修正
ユーザーとアドレスのカラム追加
購入とアドレスのアソシエーション正常化
reference型のカラム名の後の_id削除
アクティブハッシュのカラム名の後に_id追加
電話番号のカラム型をstringに

以下、ER図
https://gyazo.com/bc33b978c96eccba7f34ae933386f61e
↓
【修正後】
https://gyazo.com/583acf833c0a1d513eaadf065800b9d0