### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.includes(:user).order(created_at: "DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.includes(:user).order(created_at: "DESC")
-    @fees = ShippingFee.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.includes(:user).order(created_at: "DESC")
+    @fees = ShippingFee.all
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,11 +3,11 @@ class Item < ApplicationRecord
   has_one_attached :item_image
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  has_one :category, dependent: :destroy
-  has_one :status, dependent: :destroy
-  has_one :shipping_fee, dependent: :destroy
-  has_one :send_from,  dependent: :destroy
-  has_one :shipping_days, dependent: :destroy
+  belongs_to_active_hash :category, dependent: :destroy
+  belongs_to_active_hash :status, dependent: :destroy
+  belongs_to_active_hash :shipping_fee, dependent: :destroy
+  belongs_to_active_hash :send_from,  dependent: :destroy
+  belongs_to_active_hash :shipping_days, dependent: :destroy
 
   with_options presence: true do
     validates :name, length:{ maximum: 40 }

--- a/app/models/send_from.rb
+++ b/app/models/send_from.rb
@@ -19,7 +19,4 @@ class SendFrom < ActiveHash::Base
     { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
-  include ActiveHash::Associations
-  belongs_to :item
-  
 end

--- a/app/models/shipping_days.rb
+++ b/app/models/shipping_days.rb
@@ -6,7 +6,5 @@ class ShippingDays < ActiveHash::Base
     { id: 4, name: '4~7日で発送'},
   ]
 
-  include ActiveHash::Associations
-  belongs_to :item
   
 end

--- a/app/models/shipping_fee.rb
+++ b/app/models/shipping_fee.rb
@@ -4,8 +4,5 @@ class ShippingFee < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
-
-  include ActiveHash::Associations
-  belongs_to :item
   
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -9,7 +9,5 @@ class Status < ActiveHash::Base
     { id: 7, name: '全体的に状態が悪い'}
   ]
 
-  include ActiveHash::Associations
-  belongs_to :item
-  
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,12 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if  @items.exists? %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.item_image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +155,8 @@
         </div>
         <% end %>
       </li>
+      <% end %>
+      <% else %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
@@ -174,6 +178,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    
       <% if  @items.exists? %>
       <% @items.each do |item|%>
       <li class='list'>
@@ -157,10 +156,7 @@
       </li>
       <% end %>
       <% else %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,8 +175,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# what
商品の一覧表示機能
# why
トップページの商品の一覧表示機能をアクティブにした
名前、価格、配送料負担を明示している
## その他
テーブルにデータがなければサンプルを表示するようにした
なお、売れ切れ分岐は未機能
### 重大な調整
アクティブハッシュのアソシエーションをbelongs_to_active_hash(itemモデル)に変更
それに伴いアクティブハッシュ側のアソシエーションも削除した
理由としては、前段階までの記述だとcurrent_scope外となり、ビューに#{item.アクティブハッシュ.name}が表示されないからである
今回の変更により問題なくビューに表示された
### 挙動確認動画
**↓商品のデータがない場合は、ダミー商品が表示されている動画**
https://gyazo.com/4aec98c21d66b8367d6089df753b005b

**↓商品のデータがある場合は、商品が一覧で表示されている動画**
https://gyazo.com/0268999009812c111ed1e5a857e131b2